### PR TITLE
Added to possibility to include additional targets/exclude assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,7 @@ The options object supports the following properties:
 | ----		| ----			| ----
 | output	| string		| Output location / name of archives (without extension)
 | format	| string OR Array	| Archive formats to use, can be `'tar'` or `'zip'`
+| excludeAssets | boolean   | If set, exclude the compiler assets (i.e. to manually include targets using `targets`)
+| targets   | Array         | Array of additional targets to archive. Each item should have the `from` and `to` properties.
 
 If `options` is a string, this is eqiuvalent to passing `{output: options}`.

--- a/index.js
+++ b/index.js
@@ -48,13 +48,24 @@ WebpackArchivePlugin.prototype.apply = function(compiler) {
 			streams.push(stream);
 		}
 
-		// Add assets
-		for(let asset in compiler.assets) {
-			if(compiler.assets.hasOwnProperty(asset)) {
-				for(let stream of streams) {
-					stream.append(fs.createReadStream(compiler.assets[asset].existsAt), {name: asset});
+		// Add assets (if not excluded)
+		if (!options.excludeAssets) {
+			for(let asset in compiler.assets) {
+				if(compiler.assets.hasOwnProperty(asset)) {
+					for(let stream of streams) {
+						stream.append(fs.createReadStream(compiler.assets[asset].existsAt), {name: asset});
+					}
 				}
 			}
+		}
+
+		// Add additional targets
+		if (Array.isArray(options.targets)) {
+			options.targets.forEach(function(target) {
+				for(let stream of streams) {
+					stream.append(fs.createReadStream(target.from), {name: target.to});
+				}
+			});
 		}
 
 		// Finalize streams


### PR DESCRIPTION
In this way it is possible to produce a release package with different folder structure and content from the webpack build result.
Thank you,
 Luciano