### PR TITLE
feat: add pathPrefix option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# webpack-archive-plugin
+
+Webpack plugin to create archives of emitted files.
+
+## Installation
+
+    npm install --save-dev webpack-archive-plugin
+
+## Usage
+
+webpack.config.js:
+
+```javascript
+let ArchivePlugin = require('webpack-archive-plugin');
+
+module.exports = {
+  // ...
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  plugins: [
+    new ArchivePlugin({
+      // the output location, can be relative (to Webpack output path) or absolute
+      output: '',
+
+      // output archive filename, defaults to the Webpack output filename (above),
+      // if not present, use the basename of the path
+      filename: '',
+
+      // defaults to the array ['zip', 'tar']
+      // valid format is 'zip' and 'tar', can be a string or an array,
+      format: '',
+
+      // OPTIONAL: defaults to the empty string
+      // the file extension to use instead of 'zip' or 'tar.gz'
+      // if 'format' is Array, extension needs to be like { zip: 'zipext', tar: 'tarext' }
+      extension: '',
+
+      // OPTIONAL: defaults to the empty string
+      // the prefix for the files included in the zip/tar.gz file
+      pathPrefix: 'relative/path'
+    })
+  ],
+}
+```
+
+Will create two archives in the same directory as output.path (`__dirname/dist` in the example),
+`${output.filename}.tar.gz` and `${output.filename}.zip` containing all compiled assets.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+const archiver = require('archiver')
+const mkdirp = require('mkdirp')
+
+function WebpackArchivePlugin (options) {
+  this.options = options || {}
+}
+
+WebpackArchivePlugin.prototype.apply = function (compiler) {
+  const defaultOptions = {
+    // output location can be relative (to Webpack output path) or absolute
+    output: compiler.options.output.path,
+
+    // output filename without extension,
+    // if not present, use the basename of the path
+    filename: '',
+
+    // String|Array
+    // Archive formats to use, can be 'tar' or 'zip'
+    format: ['zip', 'tar'],
+
+    // String|Array: output file extension,
+    // if 'format' is Array, extension needs to be like { zip: 'zipext', tar: 'tarext' }
+    extension: '',
+
+    // the prefix for the files included in the archiver file
+    pathPrefix: ''
+  }
+  const options = Object.assign(defaultOptions, this.options)
+
+  if (options.pathPrefix && path.isAbsolute(options.pathPrefix)) {
+    throw new Error('"pathPrefix" must be a relative path');
+  }
+
+  // default extension
+  let extZip = 'zip'
+  let extTar = 'tar.gz'
+  if (Array.isArray(options.format) && options.extension) {
+    extZip = options.extension.zip || extZip
+    extTar = options.extension.tar || extTar
+  }
+
+  compiler.plugin('after-emit', function (compiler, callback) {
+    const outputPath = path.resolve(compiler.options.output.path, options.output)
+    const outputFilename = options.filename || compiler.options.output.filename || path.basename(outputPath)
+    const outputPathAndFilename = path.resolve(outputPath, path.basename(outputFilename))
+
+    // Build the output path folders
+    mkdirp.sync(outputPath)
+
+    // Create archive streams
+    let streams = []
+    let zip = true
+    let tar = true
+    if (options.format) {
+      if (typeof options.format === 'string') {
+        zip = (options.format === 'zip')
+        tar = (options.format === 'tar')
+      } else if (Array.isArray(options.format)) {
+        zip = (options.format.indexOf('zip') !== -1)
+        tar = (options.format.indexOf('tar') !== -1)
+      }
+    }
+    if (zip) {
+      let stream = archiver('zip')
+      stream.pipe(fs.createWriteStream(`${outputPathAndFilename}.${extZip}`))
+      streams.push(stream)
+    }
+    if (tar) {
+      let stream = archiver('tar', {
+        gzip: true,
+        gzipOptions: {
+          level: 1
+        }
+      })
+      stream.pipe(fs.createWriteStream(`${outputPathAndFilename}.${extTar}`))
+      streams.push(stream)
+    }
+
+    // Add assets
+    for (let asset in compiler.assets) {
+      if (compiler.assets.hasOwnProperty(asset)) {
+        for (let stream of streams) {
+          stream.append(fs.createReadStream(compiler.assets[asset].existsAt), {
+            name: path.join(options.pathPrefix, asset)
+          })
+        }
+      }
+    }
+
+    // Finalize streams
+    for (let stream of streams) {
+      stream.finalize()
+    }
+
+    callback()
+  })
+}
+
+module.exports = WebpackArchivePlugin

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@username/webpack-archive-plugin",
+  "version": "1.0.0",
+  "description": "Webpack plugin to create archives of emitted files.",
+  "main": "index.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/laomao800/webpack-archive-plugin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/laomao800/webpack-archive-plugin/issues"
+  },
+  "homepage": "https://github.com/laomao800/webpack-archive-plugin",
+  "keywords": [
+    "webpack",
+    "archive"
+  ],
+  "author": "laomao800 <laomao800@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "archiver": "^1.3.0",
+    "mkdirp": "^0.5.1"
+  },
+  "directories": {
+    "test": "test"
+  }
+}


### PR DESCRIPTION
Add an option `pathPrefix` to resolve https://github.com/autochthe/webpack-archive-plugin/issues/6

```js
new ArchivePlugin({
  pathPrefix: 'dist'
})
```
will get
```
my-app.zip
  |-- dist
      |-- js
      |    +-- (js files)   
      +-- index.html
```

------

Create output folder if not exist to fix https://github.com/autochthe/webpack-archive-plugin/issues/5